### PR TITLE
create.js: check whether .gitignore exists

### DIFF
--- a/commands/builds/create.js
+++ b/commands/builds/create.js
@@ -11,7 +11,11 @@ let request = require('request');
 
 function uploadCwdToSource(app, cwd, fn) {
   let tempFilePath = path.join(os.tmpdir(), uuid.v4() + '.tar.gz');
-  let ig = ignore().add(fs.readFileSync('.gitignore').toString());
+  let ig = ignore();
+  try {
+      ig.add(fs.readFileSync('.gitignore').toString());
+  }
+  catch (e) {};
   let filter = ig.createFilter();
 
   app.sources().create({}).then(function(source){


### PR DESCRIPTION
When
% heroku builds:create ...
is executed on a directory without
.gitignore the previous version failed
as fs.readSync(".gitignore") raises
ENOENT: ENOENT: no such file or directory...

This commits checks whether .gitignore
exists before calling fs.readSync
and does not call .add to the ignore
object instead.
