### PR TITLE
require usage of GNU TAR

### DIFF
--- a/commands/builds/create.js
+++ b/commands/builds/create.js
@@ -14,11 +14,9 @@ function checkTarInstall(tar) {
   let tarVersion = exec(tar+" --version").toString()
 
   if (!tarVersion.match(/GNU tar/)) {
-    throw  `This command requires GNU tar to compress your app code.
-    Please install it, or specify the '--tar' option
-
-    -------------------------
-    ` + tarVersion.toString()
+    cli.warn("Builds can fail if their code is not compressed with GNU tar.")
+    cli.warn("Please install it, or specify the '--tar' option")
+    cli.warn("Detected tar version: "+tarVersion.toString())
   }
 }
 

--- a/commands/builds/create.js
+++ b/commands/builds/create.js
@@ -8,53 +8,46 @@ let uuid = require('node-uuid');
 let os = require('os');
 let path = require('path');
 let request = require('request');
+let exec = require('child_process').execSync
 
-function uploadCwdToSource(app, cwd, fn) {
+function checkTarInstall(tar) {
+  let tarVersion = exec(tar+" --version").toString()
+
+  if (!tarVersion.match(/GNU tar/)) {
+    throw  `This command requires GNU tar to compress your app code.
+    Please install it, or specify the '--tar' option
+
+    -------------------------
+    ` + tarVersion.toString()
+  }
+}
+
+function uploadCwdToSource(app, cwd, tar, fn) {
   let tempFilePath = path.join(os.tmpdir(), uuid.v4() + '.tar.gz');
   let ig = ignore().add(fs.readFileSync('.gitignore').toString());
   let filter = ig.createFilter();
 
+  checkTarInstall(tar)
   app.sources().create({}).then(function(source){
-    let archive = archiver('tar', { gzip: true });
+    exec(tar+" cz -C "+cwd+" --exclude .git --exclude .gitmodules . > "+tempFilePath)
 
-    archive.on('finish', function (err) {
-      if (err) { throw err; }
+    let filesize = fs.statSync(tempFilePath).size;
+    let request_options = {
+      url: source.source_blob.put_url,
+      headers: {
+        'Content-Type': '',
+        'Content-Length': filesize
+      }
+    };
 
-      let filesize = fs.statSync(tempFilePath).size;
-      let request_options = {
-        url: source.source_blob.put_url,
-        headers: {
-         'Content-Type': '',
-         'Content-Length': filesize
-        }
-      };
-
-      var stream = fs.createReadStream(tempFilePath);
-      stream.on('close', function() {
-        fs.unlink(tempFilePath);
-      });
-
-      stream.pipe(request.put(request_options, function() {
-        fn(source.source_blob.get_url);
-      }));
+    var stream = fs.createReadStream(tempFilePath);
+    stream.on('close', function() {
+      fs.unlink(tempFilePath);
     });
 
-    let output = fs.createWriteStream(tempFilePath);
-    archive.pipe(output);
-    var data = {};
-    if (os.platform() === 'win32') {
-      data.mode = 0o0755;
-    }
-    archive.bulk([
-      { expand: true,
-        cwd: cwd,
-        src: ['**'],
-        dest: false,
-        filter: filter,
-        data: data,
-        dot: true
-      }
-    ]).finalize();
+    stream.pipe(request.put(request_options, function() {
+      fn(source.source_blob.get_url);
+    }));
   });
 }
 
@@ -62,10 +55,11 @@ function create(context, heroku) {
   let app = heroku.apps(context.app);
 
   var sourceUrl = context.flags['source-url'];
+  var tar = context.flags['tar'] || 'tar';
 
   var sourceUrlPromise = sourceUrl ?
       new Promise(function(resolve) { resolve(sourceUrl);}) :
-      new Promise(function(resolve) { uploadCwdToSource(app, context.cwd, resolve); });
+      new Promise(function(resolve) { uploadCwdToSource(app, context.cwd, tar, resolve); });
 
   return sourceUrlPromise.then(function(sourceGetUrl) {
     return app.builds().create({
@@ -90,6 +84,7 @@ module.exports = {
   description: 'create build',
   flags: [
     { name: 'source-url', description: 'Source URL that points to the tarball of your application\'s source code', hasValue: true},
+    { name: 'tar', description: 'Path to the executable GNU tar', hasValue: true},
     { name: 'version', description: 'Description of your new build', hasValue: true }
   ],
   run: cli.command(create)

--- a/lib/node_tar.js
+++ b/lib/node_tar.js
@@ -1,0 +1,37 @@
+let archiver = require('archiver');
+let ignore = require('ignore');
+let fs = require('fs');
+let os = require('os');
+let request = require('request');
+
+module.exports = {
+
+  call: function(cwd, file, callback) {
+    let archive = archiver('tar', { gzip: true });
+    let ig = ignore().add(fs.readFileSync('.gitignore').toString());
+    let filter = ig.createFilter();
+
+    archive.on('finish', function (err) {
+      if (err) { throw err }
+      callback()
+    })
+
+    let output = fs.createWriteStream(file)
+    archive.pipe(output)
+    var data = {}
+    if (os.platform() === 'win32') {
+      data.mode = 0o0755
+    }
+
+    archive.bulk([
+      { expand: true,
+        cwd: cwd,
+        src: ['**'],
+        dest: false,
+        filter: filter,
+        data: data,
+        dot: true
+      }
+    ]).finalize()
+  }
+}


### PR DESCRIPTION
Not using GNU TAR means we could send a archive unreadable by the build system, in which case it will fail decompressing it.

This change will fail and an error if `tar` is not available, or isn't BSD TAR, based on the version provided.