### PR TITLE
Refactor and test the builds:index command

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -1,0 +1,15 @@
+'use strict'
+
+function ago (since) {
+  const strftime = require('strftime')
+  let elapsed = Math.floor((new Date() - since) / 1000)
+  let message = strftime('%Y/%m/%d %H:%M:%S %z', since)
+  if (elapsed < 60) return `${message} (~ ${Math.floor(elapsed)}s ago)`
+  else if (elapsed < 60 * 60) return `${message} (~ ${Math.floor(elapsed / 60)}m ago)`
+  else if (elapsed < 60 * 60 * 25) return `${message} (~ ${Math.floor(elapsed / 60 / 60)}h ago)`
+  else return message
+}
+
+module.exports = {
+  ago
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "heroku-cli-util": "5.10.10",
     "ignore": "3.1.2",
     "node-uuid": "1.4.7",
-    "request": "2.72.0"
+    "request": "2.72.0",
+    "strftime": "0.10.0"
   },
   "devDependencies": {
     "jshint": "*",
@@ -34,7 +35,8 @@
     "mockdate": "2.0.1",
     "nock": "9.0.4",
     "nyc": "10.1.2",
-    "standard": "8.6.0"
+    "standard": "8.6.0",
+    "unexpected": "10.25.0"
   },
   "standard": {
     "env": "mocha"

--- a/test/commands/builds/index.js
+++ b/test/commands/builds/index.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const cmd = require('../../../commands/builds')
+const expect = require('unexpected')
+
+describe('builds index', () => {
+  beforeEach(() => cli.mockConsole())
+
+  const builds = [
+    {
+      'app': {
+        'id': 'app_uuid'
+      },
+      'buildpacks': [
+        {
+          'url': 'https://example.com/buildpack.tgz'
+        }
+      ],
+      'created_at': '2016-08-08T08:46:40Z',
+      'id': 'build_uuid',
+      'output_stream_url': 'https://example.com',
+      'release': {
+        'id': 'release_uuid'
+      },
+      'slug': {
+        'id': 'slug_uuid'
+      },
+      'source_blob': {
+        'checksum': 'SHA256:3e46dfa5cc27b79b5aab6fa054775915b65b9709e4167ac508a7684445de493a',
+        'url': 'https://example.com/source_blob.tar.gz',
+        'version': 'succeeded_blob_version',
+        'version_description': ''
+      },
+      'status': 'succeeded',
+      'updated_at': '2016-08-08T08:46:55Z',
+      'user': {
+        'email': 'damien@heroku.com',
+        'id': 'user_uuid'
+      }
+    },
+    {
+      'app': {
+        'id': 'app_uuid'
+      },
+      'buildpacks': [
+        {
+          'url': 'https://example.com/buildpack.tgz'
+        }
+      ],
+      'created_at': '2016-08-08T08:46:40Z',
+      'id': 'build_uuid',
+      'output_stream_url': 'https://example.com',
+      'release': {
+        'id': 'release_uuid'
+      },
+      'slug': {
+        'id': 'slug_uuid'
+      },
+      'source_blob': {
+        'checksum': 'SHA256:3e46dfa5cc27b79b5aab6fa054775915b65b9709e4167ac508a7684445de493a',
+        'url': 'https://example.com/source_blob.tar.gz',
+        'version': 'failed_blob_version',
+        'version_description': ''
+      },
+      'status': 'failed',
+      'updated_at': '2016-08-08T08:46:55Z',
+      'user': {
+        'email': 'damien@heroku.com',
+        'id': 'user_uuid'
+      }
+    }
+  ]
+
+  it('shows builds', () => {
+    process.stdout.columns = 80
+    let api = nock('https://api.heroku.com:443')
+      .get('/apps/myapp/builds')
+      .reply(200, builds)
+    return cmd.run({app: 'myapp', flags: {}})
+      .then(() => expect(cli.stdout, 'to equal', `=== myapp Builds
+2016/08/08 08:46:40 +0000  succeeded_blob_version  damien@heroku.com
+2016/08/08 08:46:40 +0000  failed_blob_version     damien@heroku.com
+`))
+      .then(() => expect(cli.stderr, 'to be empty'))
+      .then(() => api.done())
+  })
+})


### PR DESCRIPTION
* Instead of using console.log, we use cli.table.
* Handle limiting the number of builds returned too.