### PR TITLE
Add option to include vcs ignore files into the build

### DIFF
--- a/commands/builds/create.js
+++ b/commands/builds/create.js
@@ -88,10 +88,10 @@ module.exports = {
   help: 'Create build from contents of current dir',
   description: 'create build',
   flags: [
-    { name: 'source-url', description: 'Source URL that points to the tarball of your application\'s source code', hasValue: true },
-    { name: 'tar', description: 'Path to the executable GNU tar', hasValue: true },
-    { name: 'version', description: 'Description of your new build', hasValue: true },
-    { name: 'exclude-vcs-ignore', description: 'Exclude files ignores by VCS (.gitignore, ...) from the build', hasValue: true }
+    { name: 'source-url', description: 'source URL that points to the tarball of your application\'s source code', hasValue: true },
+    { name: 'tar', description: 'path to the executable GNU tar', hasValue: true },
+    { name: 'version', description: 'description of your new build', hasValue: true },
+    { name: 'exclude-vcs-ignore', description: 'exclude files ignores by VCS (.gitignore, ...) from the build', hasValue: true }
   ],
   run: cli.command(create)
 }

--- a/commands/builds/create.js
+++ b/commands/builds/create.js
@@ -13,10 +13,10 @@ function compressSource (context, tar, cwd, tempFile, cb) {
   let tarVersion = exec(tar + ' --version').toString()
 
   if (tarVersion.match(/GNU tar/)) {
-    let excludeVcsIgnore = context.flags['exclude-vcs-ignore'] || 'true'
+    let includeVcsIgnore = context.flags['include-vcs-ignore']
     let command = tar + ' cz -C ' + cwd + ' --exclude .git --exclude .gitmodules .'
 
-    if (excludeVcsIgnore === 'true') {
+    if (!includeVcsIgnore) {
       command += ' --exclude-vcs-ignores'
     }
 
@@ -91,7 +91,7 @@ module.exports = {
     { name: 'source-url', description: 'source URL that points to the tarball of your application\'s source code', hasValue: true },
     { name: 'tar', description: 'path to the executable GNU tar', hasValue: true },
     { name: 'version', description: 'description of your new build', hasValue: true },
-    { name: 'exclude-vcs-ignore', description: 'exclude files ignores by VCS (.gitignore, ...) from the build', hasValue: true }
+    { name: 'include-vcs-ignore', description: 'include files ignores by VCS (.gitignore, ...) from the build' }
   ],
   run: cli.command(create)
 }


### PR DESCRIPTION
Some versions of tar don't handle that option.
Also, it can be useful to include those ignored files depending of the cases.

Closes #36
cc @fjorgemota this should let you build on Ubuntu 14.04.