### PR TITLE
Add builds:cache:purge command

### DIFF
--- a/commands/builds/cache-purge.js
+++ b/commands/builds/cache-purge.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const cli = require('heroku-cli-util')
+const co = require('co')
+
+function * run (context, heroku) {
+  let r = heroku.request({
+    method: 'DELETE',
+    path: `/apps/${context.app}/build-cache`
+  })
+
+  yield cli.action(`Purging build cache for ${cli.color.app(context.app)}`, r)
+}
+
+module.exports = {
+  topic: 'builds',
+  command: 'cache:purge',
+  description: 'purge the build cache for the specified app',
+  needsApp: true,
+  needsAuth: true,
+  run: cli.command(co.wrap(run))
+}

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ exports.topic = {
 }
 
 exports.commands = [
+  require('./commands/builds/cache-purge'),
   require('./commands/builds/create'),
   require('./commands/builds/index'),
   require('./commands/builds/info'),

--- a/test/commands/builds/cache-purge.js
+++ b/test/commands/builds/cache-purge.js
@@ -1,0 +1,21 @@
+'use strict'
+const cli = require('heroku-cli-util')
+const nock = require('nock')
+const cmd = require('../../..').commands.find(c => c.topic === 'builds' && c.command === 'cache:purge')
+const expect = require('unexpected')
+
+describe('builds cache purge', () => {
+  beforeEach(() => cli.mockConsole())
+
+  it('purges the build cache', () => {
+    process.stdout.columns = 80
+    let api = nock('https://api.heroku.com:443')
+      .delete('/apps/myapp/build-cache')
+      .reply(200)
+
+    return cmd.run({app: 'myapp'})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => expect(cli.stderr, 'to equal', 'Purging build cache for myapp... done\n'))
+      .then(() => api.done())
+  })
+})


### PR DESCRIPTION
Using the new public endpoint instead of a one-off dyno.

See #52.
Merging this won't let us close that issue yet though, as there's still heroku/heroku-repo/issues/70 which is currently being discussed.