### PR TITLE
added source-tar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ If you pass a `--source-url` argument to the `create` command, a build will be c
 
 As above, build output is streamed to `stderr` and an optional `--version` argument is supported.
 
+### Create build from local tarball
+
+If you pass a `--source-tar` argument to the `create` command, a build will be created from the contents of a tarball found at the path given. The current working directory contents is not used. Example:
+
+    heroku builds:create --source-tar master.tar.gz -a example-app
+
+As above, build output is streamed to `stderr` and an optional `--version` argument is supported.
+
 ### Show build output
 
     heroku builds -a example-app # take note of the build ID you'd want to display

--- a/test/commands/builds/create.js
+++ b/test/commands/builds/create.js
@@ -39,43 +39,66 @@ describe('builds create', () => {
     }
   }
 
-  it('creates a new build', () => {
-    process.stdout.columns = 80
+  function buildMocks (urlBuild) {
     let busl = nock('https://busl.test:443')
       .get('/streams/build.log')
       .reply(200, 'Streamed Build Output')
     let api = nock('https://api.heroku.com:443')
-      .post('/sources')
-      .reply(200, source)
-      .put('/sources/1234.tgz')
-      .reply(200)
-      .post('/apps/myapp/builds')
+
+    if (!urlBuild) {
+      api.post('/sources')
+        .reply(200, source)
+        .put('/sources/1234.tgz')
+        .reply(200)
+    }
+
+    api.post('/apps/myapp/builds')
       .reply(200, build)
+
+    return {busl, api}
+  }
+
+  it('creates a new build', () => {
+    let mocks = buildMocks()
+    process.stdout.columns = 80
 
     return cmd.run({app: 'myapp', flags: {dir: process.cwd() + '/test', 'include-vcs-ignore': true}})
       .then(() => expect(cli.stdout, 'to be empty'))
       .then(() => expect(cli.stderr, 'to be empty'))
-      .then(() => api.done())
-      .then(() => busl.done())
+      .then(() => mocks.api.done())
+      .then(() => mocks.busl.done())
   })
 
   it('creates a new build with node tar', () => {
+    let mocks = buildMocks()
     process.stdout.columns = 80
-    let busl = nock('https://busl.test:443')
-      .get('/streams/build.log')
-      .reply(200, 'Streamed Build Output')
-    let api = nock('https://api.heroku.com:443')
-      .post('/sources')
-      .reply(200, source)
-      .put('/sources/1234.tgz')
-      .reply(200)
-      .post('/apps/myapp/builds')
-      .reply(200, build)
 
     return cmd.run({app: 'myapp', flags: {dir: process.cwd() + '/test', tar: 'no-tar'}})
       .then(() => expect(cli.stdout, 'to be empty'))
       .then(() => expect(cli.stderr, 'to contain', 'Couldn\'t detect GNU tar. Builds could fail due to decompression errors'))
-      .then(() => api.done())
-      .then(() => busl.done())
+      .then(() => mocks.api.done())
+      .then(() => mocks.busl.done())
+  })
+
+  it('creates a new build from an existing file', () => {
+    let mocks = buildMocks()
+    process.stdout.columns = 80
+
+    // not a tar file, but will suffice for testing purposes
+    return cmd.run({app: 'myapp', flags: {'source-tar': process.cwd() + '/test/helpers.js'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => mocks.api.done())
+      .then(() => mocks.busl.done())
+  })
+
+  it('creates a new build from URL', () => {
+    let mocks = buildMocks(true)
+    process.stdout.columns = 80
+
+    // not a tar file, but will suffice for testing purposes
+    return cmd.run({app: 'myapp', flags: {'source-url': 'https://example.com/1234.tgz'}})
+      .then(() => expect(cli.stdout, 'to be empty'))
+      .then(() => mocks.api.done())
+      .then(() => mocks.busl.done())
   })
 })


### PR DESCRIPTION
I added a `source-tar` option so that you could build a custom tar locally without having to upload it somewhere. I wanted to be able to add custom excludes during the tar generation.

If this looks good, I'll add the docs before merge. I wanted to get some feedback first to see if this is a good direction.

Sample deploy script I use now:

```bash
#!/bin/bash

rm deploy.tar.gz
tar cvf deploy.tar *.j* public/ src/
gzip -9 deploy.tar
heroku builds:create -a my-app-name --source-tar deploy.tar.gz
```
