### PR TITLE
Switch to the new GitHub Actions runner groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         node-version: [ 16.x ]
-        os: [ pub-hk-ubuntu-22.04-small, pub-hk-ubuntu-22.04-arm-large ]
+        os: [ ubuntu-24.04, pub-hk-ubuntu-24.04-arm-small ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The GitHub Actions runners groups have just been updated to:
1. Add Ubuntu 24.04 runners
2. Separate out the static-IP vs no-static IP use cases

This switches this repo to using the new groups for the ARM runner, and switches the `x86_64` job back to using the standard GitHub runner as recommended here:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd

(Note: Since this is a public repo, custom runners are not needed to be able to Git clone the repo in CI, therefore should only be used when more compute, ARM CPUs or Git writes are required.)

I've also adjusted the size of the ARM runner down to match the standard runner (both are 4 vCPU). The tests in this repo only take 5 seconds to run, so don't need 16 vCPU.