### PR TITLE
Fix restricting number of builds

### DIFF
--- a/src/commands/builds/index.ts
+++ b/src/commands/builds/index.ts
@@ -20,6 +20,7 @@ export default class Index extends Command {
     const {flags} = await this.parse(Index)
     const {app, num} = flags
     const {body: builds} = await this.heroku.get<Heroku.Build[]>(`/apps/${app}/builds`, {
+      partial: true,
       headers: {Range: `created_at ..; max=${num || 15}, order=desc`},
     })
     ux.styledHeader(`${app} Builds`)


### PR DESCRIPTION
[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001zS8sMYAS/view)

This fixes a bug that causes the `-n` flag not to work, and also breaks the default behavior to get the maximum number of results (instead of the intended 15).