### PR TITLE
Update version script to use oclif instead of oclif-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/heroku/heroku-build",
   "scripts": {
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
-    "version": "oclif-dev readme && git add README.md",
+    "version": "oclif readme && git add README.md",
     "build": "rm -rf dist && tsc -b && oclif manifest && oclif readme && mv oclif.manifest.json ./dist/oclif.manifest.json && cp README.md ./dist/README.md && node scripts/prepack.mjs"
   },
   "oclif": {


### PR DESCRIPTION
Fixes `version` script to use the oclif v2 `oclif` instead of `oclif-dev`