### PR TITLE
chore: Update files to be packed when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/heroku/heroku-builds",
   "scripts": {
     "build": "rm -rf dist && tsc -b && oclif manifest && oclif readme && mv oclif.manifest.json ./dist/oclif.manifest.json && cp README.md ./dist/README.md",
-    "prepare": "yarn build",
+    "prepack": "yarn build",
     "test": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "version": "oclif readme && git add README.md"
   },
@@ -71,8 +71,6 @@
     "typescript": "^5"
   },
   "files": [
-    "/bin",
-    "/dist",
-    "/oclif.manifest.json"
+    "/dist"
   ]
 }


### PR DESCRIPTION
## Description

On our previous PR we missed to update the `files` entry in `package.json` to only include the `/dist` directory when packaging.

This PR corrects the entry and scripts for publishing.

## SOC2 Compliance
GUS Work Item: [W-17908891](https://gus.lightning.force.com/a07EE00002AKQXSYA5)