### PR TITLE
fix: Do not truncate build id

### DIFF
--- a/src/commands/builds/index.ts
+++ b/src/commands/builds/index.ts
@@ -61,6 +61,9 @@ export default class Index extends Command {
           return color.magenta(row.user?.email?.replace(/@addons\.heroku\.com$/, ''))
         }
       }
+    },
+    {
+      'no-truncate': true,
     })
   }
 }


### PR DESCRIPTION
When the terminal is small, the build id gets truncated. This id is important for performing other commands, so it quite annoying that this is truncated. It does not appear that oclif has a way to only turn off truncation on a single column, so I had to add the flag on the whole table. If it did have column-level truncation settings, it would be nice to truncate `Source Version` or perhaps make the `Created At` less verbose when the terminal is small.

# Demo

## Before

```
❯ h builds
=== rbrainard-cnb-layout-a Builds

 ID   Source Version                           Created At                            Duration Status    User                
 ──── ──────────────────────────────────────── ───────────────────────────────────── ──────── ───────── ─────────────────── 
 e52… 0d1e146943b9fa353779b37fc29dfc0c4d335a8c 2025/09/25 15:31:11 -0400 (~ 19h ago) 2m 13s   succeeded brainard@heroku.com 
 fbe… 92e3c107e27200b68fda9582497e428ee48a6700 2025/09/25 12:46:02 -0400 (~ 22h ago) 54s      succeeded brainard@heroku.com
```

## After

```
❯ h builds
=== rbrainard-cnb-layout-a Builds

 ID                                   Source Version                           Created At                            Duration Status    User                
 ──────────────────────────────────── ──────────────────────────────────────── ───────────────────────────────────── ──────── ───────── ─────────────────── 
 e52d28aa-b625-41ce-ba9d-e330021a3182 0d1e146943b9fa353779b37fc29dfc0c4d335a8c 2025/09/25 15:31:11 -0400 (~ 19h ago) 2m 13s   succeeded brainard@heroku.com 
 fbee3319-870b-4395-bd7c-2dffba3de45f 92e3c107e27200b68fda9582497e428ee48a6700 2025/09/25 12:46:02 -0400 (~ 22h ago) 54s      succeeded brainard@heroku.com 
```